### PR TITLE
fix: iOS background crash

### DIFF
--- a/ds_test.go
+++ b/ds_test.go
@@ -15,7 +15,8 @@ func TestCase(t *testing.T) {
 	defer cancel()
 
 	key := testingKey(t)
-	ds, err := NewSQLCipherDatastore("sqlite3", filepath.Join(t.TempDir(), "test.sqlite"), "blocks", key)
+	salt := testingSalt(t)
+	ds, err := NewSQLCipherDatastore("sqlite3", filepath.Join(t.TempDir(), "test.sqlite"), "blocks", key, salt)
 	require.NoError(t, err)
 	require.NoError(t, ds.Put(ctx, datastore.KeyWithNamespaces([]string{"A", "B"}), ([]byte)("42")))
 	qr, err := ds.Query(ctx, query.Query{Prefix: "a"})

--- a/open.go
+++ b/open.go
@@ -13,20 +13,20 @@ var (
 	onlyOne repo.OnlyOne
 )
 
-func Open(dbPath string, key []byte) (repo.Repo, error) {
+func Open(dbPath string, key []byte, salt []byte) (repo.Repo, error) {
 	fn := func() (repo.Repo, error) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		return open(ctx, dbPath, key)
+		return open(ctx, dbPath, key, salt)
 	}
 	return onlyOne.Open(dbPath, fn)
 }
 
-func open(ctx context.Context, dbPath string, key []byte) (repo.Repo, error) {
+func open(ctx context.Context, dbPath string, key []byte, salt []byte) (repo.Repo, error) {
 	packageLock.Lock()
 	defer packageLock.Unlock()
 
-	uroot, err := OpenSQLCipherDatastore("sqlite3", dbPath, tableName, key)
+	uroot, err := OpenSQLCipherDatastore("sqlite3", dbPath, tableName, key, salt)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiate datastore")
 	}

--- a/repo_test.go
+++ b/repo_test.go
@@ -13,23 +13,24 @@ import (
 
 func TestRepo(t *testing.T) {
 	key := testingKey(t)
+	salt := testingSalt(t)
 	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
 
-	isInit, err := IsInitialized(dbPath, key)
+	isInit, err := IsInitialized(dbPath, key, salt)
 	require.NoError(t, err)
 	require.False(t, isInit)
 
-	err = Init(dbPath, key, &config.Config{})
+	err = Init(dbPath, key, salt, &config.Config{})
 	require.NoError(t, err)
 
-	isInit, err = IsInitialized(dbPath, key)
+	isInit, err = IsInitialized(dbPath, key, salt)
 	require.NoError(t, err)
 	require.True(t, isInit)
 
-	err = Init(dbPath, key, &config.Config{})
+	err = Init(dbPath, key, salt, &config.Config{})
 	require.NoError(t, err)
 
-	r, err := Open(dbPath, key)
+	r, err := Open(dbPath, key, salt)
 	require.NoError(t, err)
 	defer requireClose(t, r)
 
@@ -42,12 +43,13 @@ func TestRepo(t *testing.T) {
 
 func TestSetAPIAddrTwice(t *testing.T) {
 	key := testingKey(t)
+	salt := testingSalt(t)
 	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
 
-	err := Init(dbPath, key, &config.Config{})
+	err := Init(dbPath, key, salt, &config.Config{})
 	require.NoError(t, err)
 
-	r, err := Open(dbPath, key)
+	r, err := Open(dbPath, key, salt)
 	require.NoError(t, err)
 	defer requireClose(t, r)
 


### PR DESCRIPTION
Add new options when creating/opening DB:
`journal_mode=WAL`
`cipher_plaintext_header_size=32`
`cipher_salt=###`

https://github.com/sqlcipher/sqlcipher/issues/255#issuecomment-355063368
https://developer.apple.com/library/archive/technotes/tn2408/_index.html

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>